### PR TITLE
Fix mention regex to handle digits and punctuation

### DIFF
--- a/lib/utils/mentions.test.ts
+++ b/lib/utils/mentions.test.ts
@@ -1,0 +1,13 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { extractMentions } from './mentions.ts'
+
+test('extractMentions supports digits and ignores punctuation', () => {
+  const text = 'Salut @User1, comment ça va ? Et @Jean Pierre aussi !'
+  const mentions = extractMentions(text)
+  assert.deepEqual(
+    mentions.map((m) => m.username),
+    ['User1', 'Jean Pierre']
+  )
+})

--- a/lib/utils/mentions.ts
+++ b/lib/utils/mentions.ts
@@ -13,8 +13,11 @@ export interface MentionMatch {
 
 // Fonction pour extraire les mentions d'un texte
 export function extractMentions(text: string): MentionMatch[] {
-  // Regex simple qui capture maximum 2 mots après @
-  const mentionRegex = /@([A-Za-zÀ-ÿ]+(?:\s+[A-Za-zÀ-ÿ]+)?)/g;
+  // Regex qui accepte les chiffres, limite la mention à deux mots et
+  // arrête la capture à un espace ou un signe de ponctuation pour éviter
+  // d'inclure des caractères non désirés dans la mention
+  const mentionRegex =
+    /@([A-Za-zÀ-ÿ0-9]+(?:\s+[A-Za-zÀ-ÿ0-9]+)?)(?=\s|$|[,.!?;:])/g;
   const mentions: MentionMatch[] = [];
   let match;
 


### PR DESCRIPTION
## Summary
- improve mention extraction to handle digits and stop at punctuation
- add tests covering mentions with numbers

## Testing
- `node --experimental-strip-types --test lib/utils/mentions.test.ts`
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_6895ae50ce1483309043cec4988a3564